### PR TITLE
update python client tutorials for data access

### DIFF
--- a/tutorials/ClientAuthenticationWithEDLTokens.adoc
+++ b/tutorials/ClientAuthenticationWithEDLTokens.adoc
@@ -234,6 +234,9 @@ pd_dataset = pydap.client.open_url(dataset_url, session=my_session, protocol="da
 
 ----
 
+If you want to see it in action, you can go to PyDAP's static documentation and navigate to https://pydap.github.io/pydap/notebooks/Authentication.html[Basic Authentication] under Examples. Other Example notebooks can further illustrate workflows starting with Token-based authentication.
+
+
 :leveloffset: -1
 == Clients that do not work with EDL tokens
 :leveloffset: +1

--- a/tutorials/DataAccessTutorials.adoc
+++ b/tutorials/DataAccessTutorials.adoc
@@ -21,12 +21,12 @@ data access activity, possibly written as a shell script.
 *  link:https://opendap.github.io/documentation/tutorials/nccopy_tutorial.html[nccopy tutorial]
 
 == Python client tutorials
-Among the most stable and widely used within the Python ecosystem are NetCDF and https://github.com/pydap/pydap[PyDAP]. Xarray, a widely popular package within the Pangeo ecosystem uses both as a backend `engine`, and both NetCDF and PyDAP are required dependencies for Xarray, which means installing Xarray installs NetCDF and PyDAP by default.  Between the two packages, we recommend getting started with PyDAP to best exploit OPeNDAP resources, because PyDAP has the following characteristics:
+Among the most stable and widely used within the Python ecosystem are NetCDF and https://pydap.github.io/pydap/intro.html[PyDAP]. Xarray, a widely popular package within the Pangeo ecosystem uses both as a backend `engine`, and both NetCDF and https://pydap.github.io/pydap/intro.html[PyDAP] are required dependencies for Xarray, which means installing Xarray installs NetCDF and https://pydap.github.io/pydap/intro.html[PyDAP] by default.  Between the two packages, we recommend getting started with https://pydap.github.io/pydap/intro.html[PyDAP] to best exploit OPeNDAP resources, because PyDAP has the following characteristics:
 
 * Pure python implementation of the DAP protocol.
-* Ppen-source, developed and maintained by the OPeNDAP team and the broad PyDAP/OPeNDAP community.
-* Packs its own lightweight (pydap) server.
-* Server-side and data-proximmate subsetting. OPeNDAP servers are highly specialized to subset the original dataset. With PyDAP, a user can add constraint expressions to the URL, a powerful tool once you get familiarize with.
+* Open-source, developed and maintained by the OPeNDAP team and the broad PyDAP/OPeNDAP community.
+* Has its own lightweight server implementation.
+* Server-side and data-proximmate subsetting. OPeNDAP servers are highly specialized to subset the original dataset. With https://pydap.github.io/pydap/intro.html[PyDAP], a user can add constraint expressions to the URL, a powerful tool once you get familiarize with.
 
 
 Below are a combination of static and interactive resources. You can click the associated image image:https://static.mybinder.org/badge_logo.svg[fit=line] Binder badge to run the notebooks in your browser.
@@ -35,7 +35,9 @@ Below are a combination of static and interactive resources. You can click the a
 	- https://pydap.github.io/pydap/notebooks/Authentication.html[Token-based Authentication] (necessary for example to access NASAEarth data).
 	- Tutorial workflows for accesing and plotting various NASA and Non-NASA data product (https://pydap.github.io/pydap/notebooks/CMIP6.html[CMIP6], https://pydap.github.io/pydap/notebooks/ECCO.html[ECCOv4], https://pydap.github.io/pydap/notebooks/PACE.html[PACE] and https://pydap.github.io/pydap/notebooks/SWOT.html[SWOT]).
 
-* link:https://github.com/OPENDAP/ESIP2024/tree/main[Interactive jupyter notebooks] image:https://static.mybinder.org/badge_logo.svg[fit=line, link="https://mybinder.org/v2/gh/OPENDAP/ESIP2024/main"], showing similar workflows with PyDAP as that of its official documentation. The DAP2 example is that when working with https://pydap.github.io/pydap/notebooks/CMIP6.html[CMIP6] data.
+* link:https://github.com/OPENDAP/ESIP2024/tree/main[Interactive jupyter notebooks] image:https://static.mybinder.org/badge_logo.svg[fit=line, link="https://mybinder.org/v2/gh/OPENDAP/ESIP2024/main"], showing similar workflows with PyDAP as that of its official documentation. The DAP2 example is that when working with https://pydap.github.io/pydap/notebooks/CMIP6.html[CMIP6] data. 
+	- *Requirements*: https://urs.earthdata.nasa.gov/home[EDL] account, and create a token for authentication.
+	- *NOTE*: https://github.com/OPENDAP/ESIP2024/blob/main/binder/GetStarted.ipynb[GetStarted.ipynb] notebook should be executed first as it creates local file with https://urs.earthdata.nasa.gov/home[EDL] credentials needed to access data in the all other notebooks.
 
 
 Older python resource:

--- a/tutorials/DataAccessTutorials.adoc
+++ b/tutorials/DataAccessTutorials.adoc
@@ -21,18 +21,24 @@ data access activity, possibly written as a shell script.
 *  link:https://opendap.github.io/documentation/tutorials/nccopy_tutorial.html[nccopy tutorial]
 
 == Python client tutorials
-Python clients like NetCDF, Xarray, and PyDAp are best explained in a Jupyter (aka iPython) notebook.
-Note: We initially used Binder for these notebooks, but recent changes to Binder cause issue
-we cannot easily resolve. For now, we are using notebooks that use Google Colab. The notebooks
-are equivalent to the Binder versions, with some minor differences with respect to differences
-between the Colab Binder virtual environments.
+Among the most stable and widely used within the Python ecosystem are NetCDF and https://github.com/pydap/pydap[PyDAP]. Xarray, a widely popular package within the Pangeo ecosystem uses both as a backend `engine`, and both NetCDF and PyDAP are required dependencies for Xarray, which means installing Xarray installs NetCDF and PyDAP by default.  Between the two packages, we recommend getting started with PyDAP to best exploit OPeNDAP resources, because PyDAP has the following characteristics:
 
-You can click the associated image:https://colab.research.google.com/assets/colab-badge.svg[fit=line]
-Google Colab badge to run the notebook in your browser.
+* Pure python implementation of the DAP protocol.
+* Ppen-source, developed and maintained by the OPeNDAP team and the broad PyDAP/OPeNDAP community.
+* Packs its own lightweight (pydap) server.
+* Server-side and data-proximmate subsetting. OPeNDAP servers are highly specialized to subset the original dataset. With PyDAP, a user can add constraint expressions to the URL, a powerful tool once you get familiarize with.
 
-*  link:https://github.com/OPENDAP/NASA-tutorials/blob/main/tutorials/colab/0.NASA_EDL_Login.ipynb[Earthdata Login and Configuration]
-image:https://colab.research.google.com/assets/colab-badge.svg[fit=line, link="https://colab.research.google.com/github/OPENDAP/NASA-tutorials/blob/main/tutorials/colab/0.NASA_EDL_Login.ipynb"] -
-An iPython notebook tutorial to help with the NASA Earthdata Login and configuration for OPeNDAP.
+
+Below are a combination of static and interactive resources. You can click the associated image image:https://static.mybinder.org/badge_logo.svg[fit=line] Binder badge to run the notebooks in your browser.
+
+* PyDAP's https://pydap.github.io/pydap/intro.html[documentation] - Inside you will find static tutorials, mostly with DAP4 protocol. Some of the example include working with Constraint Expressions.
+	- https://pydap.github.io/pydap/notebooks/Authentication.html[Token-based Authentication] (necessary for example to access NASAEarth data).
+	- Tutorial workflows for accesing and plotting various NASA and Non-NASA data product (https://pydap.github.io/pydap/notebooks/CMIP6.html[CMIP6], https://pydap.github.io/pydap/notebooks/ECCO.html[ECCOv4], https://pydap.github.io/pydap/notebooks/PACE.html[PACE] and https://pydap.github.io/pydap/notebooks/SWOT.html[SWOT]).
+
+* link:https://github.com/OPENDAP/ESIP2024/tree/main[Interactive jupyter notebooks] image:https://static.mybinder.org/badge_logo.svg[fit=line, link="https://mybinder.org/v2/gh/OPENDAP/ESIP2024/main"], showing similar workflows with PyDAP as that of its official documentation. The DAP2 example is that when working with https://pydap.github.io/pydap/notebooks/CMIP6.html[CMIP6] data.
+
+
+Older python resource:
 
 *  link:https://github.com/OPENDAP/NASA-tutorials/blob/main/tutorials/colab/1.netcdf_tutorial.ipynb[NetCDF-python w/DAP4]
 image:https://colab.research.google.com/assets/colab-badge.svg[fit=line, link="https://colab.research.google.com/github/OPENDAP/NASA-tutorials/blob/main/tutorials/colab/1.netcdf_tutorial.ipynb"] -
@@ -44,13 +50,6 @@ to the remote service.
 image:https://colab.research.google.com/assets/colab-badge.svg[fit=line, link="https://colab.research.google.com/github/OPENDAP/NASA-tutorials/blob/main/tutorials/colab/2.xarray_netcdf_tutorial.ipynb"] -
 An iPython notebook tutorial for remote data access using Xarray.
 
-*  link:https://github.com/OPENDAP/NASA-tutorials/blob/main/tutorials/colab/3.pydap_dap4_basic.ipynb[PyDAP w/DAP4]
-image:https://colab.research.google.com/assets/colab-badge.svg[fit=line, link="https://colab.research.google.com/github/OPENDAP/NASA-tutorials/blob/main/tutorials/colab/3.pydap_dap4_basic.ipynb"] -
-An iPython notebook tutorial for PyDAP with DAP4 data access examples
-
-* link:https://github.com/OPENDAP/NASA-tutorials/blob/main/tutorials/colab/4.pydap_dap2_basic.ipynb[PyDAP w/DAP2]
-image:https://colab.research.google.com/assets/colab-badge.svg[fit=line, link="https://colab.research.google.com/github/OPENDAP/NASA-tutorials/blob/main/tutorials/colab/4.pydap_dap2_basic.ipynb"] -
-An iPython notebook tutorial for PyDAP with DAP2 access examples.
 
 == Matlab
 * link:https://opendap.github.io/documentation/tutorials/matlab_tutorial.html[Matlab Tutorial for remote data access] (beta).


### PR DESCRIPTION
Closes #23 by updating the tutorials for data access using python.

- adds links to PyDAP's official documentation for static examples
- adds links to ESIP2024 executable tutorials, and a shortcut to the BInder Badge to directly to into interactive executable mode
- Keeps resources from 2023's NASA tutorials (ESIP2023) that uses xarray+netCDF library

 
I build the documentation locally and looks good.

